### PR TITLE
Add String Method to UserID

### DIFF
--- a/internal/domain/user/user_id.go
+++ b/internal/domain/user/user_id.go
@@ -4,6 +4,10 @@ import "errors"
 
 type UserID string
 
+func (id UserID) String() string {
+	return string(id)
+}
+
 func NewUserID(s string) (UserID, error) {
 	if s == "" {
 		return "", errors.New("user id is empty")

--- a/internal/domain/user/user_id_test.go
+++ b/internal/domain/user/user_id_test.go
@@ -30,12 +30,24 @@ func TestNewUserID(t *testing.T) {
 
 func TestUserIDString(t *testing.T) {
 	t.Parallel()
-	s := "792bae02-3587-435f-a98e-3756f8695441"
-	id, err := NewUserID(s)
-	if err != nil {
-		t.Fatalf("expected no error, but got %v", err)
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"success user id string", "792bae02-3587-435f-a98e-3756f8695441"},
+		{"success user id string", "google-oauth2|000000000000000000000"},
 	}
-	if id.String() != s {
-		t.Errorf("expected %s, but got %s", s, id.String())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := NewUserID(tt.id)
+			if err != nil {
+				t.Fatalf("expected no error, but got %v", err)
+			}
+			if id.String() != tt.id {
+				t.Errorf("expected %s, but got %s", tt.id, id.String())
+			}
+		})
 	}
 }

--- a/internal/domain/user/user_id_test.go
+++ b/internal/domain/user/user_id_test.go
@@ -27,3 +27,15 @@ func TestNewUserID(t *testing.T) {
 		})
 	}
 }
+
+func TestUserIDString(t *testing.T) {
+	t.Parallel()
+	s := "792bae02-3587-435f-a98e-3756f8695441"
+	id, err := NewUserID(s)
+	if err != nil {
+		t.Fatalf("expected no error, but got %v", err)
+	}
+	if id.String() != s {
+		t.Errorf("expected %s, but got %s", s, id.String())
+	}
+}

--- a/internal/domain/user/user_id_test.go
+++ b/internal/domain/user/user_id_test.go
@@ -17,36 +17,15 @@ func TestNewUserID(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := NewUserID(tt.id)
+			id, err := NewUserID(tt.id)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
 			if !tt.success && err == nil {
 				t.Errorf("expected error, but got nil")
 			}
-		})
-	}
-}
-
-func TestUserIDString(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		id   string
-	}{
-		{"success user id string", "792bae02-3587-435f-a98e-3756f8695441"},
-		{"success user id string", "google-oauth2|000000000000000000000"},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			id, err := NewUserID(tt.id)
-			if err != nil {
-				t.Fatalf("expected no error, but got %v", err)
-			}
-			if id.String() != tt.id {
-				t.Errorf("expected %s, but got %s", tt.id, id.String())
+			if tt.success && id.String() != tt.id {
+				t.Errorf("String() = %v, want %v", id.String(), tt.id)
 			}
 		})
 	}

--- a/internal/interface/grpc/auth/handler.go
+++ b/internal/interface/grpc/auth/handler.go
@@ -46,7 +46,7 @@ func (h *AuthHandler) ExchangeCode(ctx context.Context, req *authv1.ExchangeCode
 	grpc.SendHeader(ctx, metadata.Pairs("refresh-token", token.RefreshToken()))
 
 	return &authv1.ExchangeCodeResponse{
-		UserId:      string(user.ID()),
+		UserId:      user.ID().String(),
 		AccessToken: token.AccessToken(),
 	}, nil
 }
@@ -75,7 +75,7 @@ func (h *AuthHandler) VerifyToken(ctx context.Context, req *authv1.VerifyTokenRe
 	}
 
 	return &authv1.VerifyTokenResponse{
-		UserId: string(user.ID()),
+		UserId: user.ID().String(),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Add `String()` method to `UserID` (implements `fmt.Stringer`)
- Replace `string(user.ID())` casts in the auth handler with `user.ID().String()`

Closes #179

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)