### PR TITLE
update: propagate context through usecase, provider, and HTTP clients

### DIFF
--- a/internal/application/auth/usecase.go
+++ b/internal/application/auth/usecase.go
@@ -1,19 +1,21 @@
 package auth
 
 import (
+	"context"
+
 	"github.com/qkitzero/auth-service/internal/application/identity"
 	"github.com/qkitzero/auth-service/internal/domain/token"
 	"github.com/qkitzero/auth-service/internal/domain/user"
 )
 
 type AuthUsecase interface {
-	Login(redirectURI string) (string, error)
-	ExchangeCode(code, redirectURI string) (token.Token, error)
-	VerifyToken(accessToken string) (user.User, error)
-	RefreshToken(refreshToken string) (token.Token, error)
-	RevokeToken(refreshToken string) error
-	Logout(returnTo string) (string, error)
-	GetM2MToken(clientID, clientSecret string) (token.M2MToken, error)
+	Login(ctx context.Context, redirectURI string) (string, error)
+	ExchangeCode(ctx context.Context, code, redirectURI string) (token.Token, error)
+	VerifyToken(ctx context.Context, accessToken string) (user.User, error)
+	RefreshToken(ctx context.Context, refreshToken string) (token.Token, error)
+	RevokeToken(ctx context.Context, refreshToken string) error
+	Logout(ctx context.Context, returnTo string) (string, error)
+	GetM2MToken(ctx context.Context, clientID, clientSecret string) (token.M2MToken, error)
 }
 
 type authUsecase struct {
@@ -26,12 +28,12 @@ func NewAuthUsecase(identityProvider identity.Provider) AuthUsecase {
 	}
 }
 
-func (u *authUsecase) Login(redirectURI string) (string, error) {
-	return u.identityProvider.Login(redirectURI)
+func (u *authUsecase) Login(ctx context.Context, redirectURI string) (string, error) {
+	return u.identityProvider.Login(ctx, redirectURI)
 }
 
-func (u *authUsecase) ExchangeCode(code, redirectURI string) (token.Token, error) {
-	result, err := u.identityProvider.ExchangeCode(code, redirectURI)
+func (u *authUsecase) ExchangeCode(ctx context.Context, code, redirectURI string) (token.Token, error) {
+	result, err := u.identityProvider.ExchangeCode(ctx, code, redirectURI)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +41,8 @@ func (u *authUsecase) ExchangeCode(code, redirectURI string) (token.Token, error
 	return token.NewToken(result.AccessToken, result.RefreshToken)
 }
 
-func (u *authUsecase) VerifyToken(accessToken string) (user.User, error) {
-	result, err := u.identityProvider.VerifyToken(accessToken)
+func (u *authUsecase) VerifyToken(ctx context.Context, accessToken string) (user.User, error) {
+	result, err := u.identityProvider.VerifyToken(ctx, accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +55,8 @@ func (u *authUsecase) VerifyToken(accessToken string) (user.User, error) {
 	return user.NewUser(userID), nil
 }
 
-func (u *authUsecase) RefreshToken(refreshToken string) (token.Token, error) {
-	result, err := u.identityProvider.RefreshToken(refreshToken)
+func (u *authUsecase) RefreshToken(ctx context.Context, refreshToken string) (token.Token, error) {
+	result, err := u.identityProvider.RefreshToken(ctx, refreshToken)
 	if err != nil {
 		return nil, err
 	}
@@ -62,16 +64,16 @@ func (u *authUsecase) RefreshToken(refreshToken string) (token.Token, error) {
 	return token.NewToken(result.AccessToken, result.RefreshToken)
 }
 
-func (u *authUsecase) RevokeToken(refreshToken string) error {
-	return u.identityProvider.RevokeToken(refreshToken)
+func (u *authUsecase) RevokeToken(ctx context.Context, refreshToken string) error {
+	return u.identityProvider.RevokeToken(ctx, refreshToken)
 }
 
-func (u *authUsecase) Logout(returnTo string) (string, error) {
-	return u.identityProvider.Logout(returnTo)
+func (u *authUsecase) Logout(ctx context.Context, returnTo string) (string, error) {
+	return u.identityProvider.Logout(ctx, returnTo)
 }
 
-func (u *authUsecase) GetM2MToken(clientID, clientSecret string) (token.M2MToken, error) {
-	result, err := u.identityProvider.GetM2MToken(clientID, clientSecret)
+func (u *authUsecase) GetM2MToken(ctx context.Context, clientID, clientSecret string) (token.M2MToken, error) {
+	result, err := u.identityProvider.GetM2MToken(ctx, clientID, clientSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/application/auth/usecase_test.go
+++ b/internal/application/auth/usecase_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -40,11 +41,11 @@ func TestLogin(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().Login(tt.redirectURI).Return("login url", tt.loginErr).AnyTimes()
+			mockIdentityProvider.EXPECT().Login(gomock.Any(), tt.redirectURI).Return("login url", tt.loginErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			_, err := authUsecase.Login(tt.redirectURI)
+			_, err := authUsecase.Login(context.Background(), tt.redirectURI)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -91,11 +92,11 @@ func TestExchangeCode(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().ExchangeCode(tt.code, tt.redirectURI).Return(tt.tokenResult, tt.exchangeCodeErr).AnyTimes()
+			mockIdentityProvider.EXPECT().ExchangeCode(gomock.Any(), tt.code, tt.redirectURI).Return(tt.tokenResult, tt.exchangeCodeErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			_, err := authUsecase.ExchangeCode(tt.code, tt.redirectURI)
+			_, err := authUsecase.ExchangeCode(context.Background(), tt.code, tt.redirectURI)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -146,11 +147,11 @@ func TestVerifyToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().VerifyToken(tt.accessToken).Return(tt.verifyResult, tt.verifyTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().VerifyToken(gomock.Any(), tt.accessToken).Return(tt.verifyResult, tt.verifyTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			_, err := authUsecase.VerifyToken(tt.accessToken)
+			_, err := authUsecase.VerifyToken(context.Background(), tt.accessToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -194,11 +195,11 @@ func TestRefreshToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().RefreshToken(tt.refreshToken).Return(tt.tokenResult, tt.refreshTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().RefreshToken(gomock.Any(), tt.refreshToken).Return(tt.tokenResult, tt.refreshTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			_, err := authUsecase.RefreshToken(tt.refreshToken)
+			_, err := authUsecase.RefreshToken(context.Background(), tt.refreshToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -233,11 +234,11 @@ func TestRevokeToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().RevokeToken(tt.refreshToken).Return(tt.revokeTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().RevokeToken(gomock.Any(), tt.refreshToken).Return(tt.revokeTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			err := authUsecase.RevokeToken(tt.refreshToken)
+			err := authUsecase.RevokeToken(context.Background(), tt.refreshToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -278,11 +279,11 @@ func TestLogout(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().Logout(tt.returnTo).Return("logout url", tt.logoutErr).AnyTimes()
+			mockIdentityProvider.EXPECT().Logout(gomock.Any(), tt.returnTo).Return("logout url", tt.logoutErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			_, err := authUsecase.Logout(tt.returnTo)
+			_, err := authUsecase.Logout(context.Background(), tt.returnTo)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -329,11 +330,11 @@ func TestGetM2MToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().GetM2MToken(tt.clientID, tt.clientSecret).Return(tt.tokenResult, tt.getM2MTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().GetM2MToken(gomock.Any(), tt.clientID, tt.clientSecret).Return(tt.tokenResult, tt.getM2MTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
-			_, err := authUsecase.GetM2MToken(tt.clientID, tt.clientSecret)
+			_, err := authUsecase.GetM2MToken(context.Background(), tt.clientID, tt.clientSecret)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}

--- a/internal/application/auth/usecase_test.go
+++ b/internal/application/auth/usecase_test.go
@@ -41,7 +41,7 @@ func TestLogin(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().Login(gomock.Any(), tt.redirectURI).Return("login url", tt.loginErr).AnyTimes()
+			mockIdentityProvider.EXPECT().Login(context.Background(), tt.redirectURI).Return("login url", tt.loginErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
@@ -92,7 +92,7 @@ func TestExchangeCode(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().ExchangeCode(gomock.Any(), tt.code, tt.redirectURI).Return(tt.tokenResult, tt.exchangeCodeErr).AnyTimes()
+			mockIdentityProvider.EXPECT().ExchangeCode(context.Background(), tt.code, tt.redirectURI).Return(tt.tokenResult, tt.exchangeCodeErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
@@ -147,7 +147,7 @@ func TestVerifyToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().VerifyToken(gomock.Any(), tt.accessToken).Return(tt.verifyResult, tt.verifyTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().VerifyToken(context.Background(), tt.accessToken).Return(tt.verifyResult, tt.verifyTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
@@ -195,7 +195,7 @@ func TestRefreshToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().RefreshToken(gomock.Any(), tt.refreshToken).Return(tt.tokenResult, tt.refreshTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().RefreshToken(context.Background(), tt.refreshToken).Return(tt.tokenResult, tt.refreshTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
@@ -234,7 +234,7 @@ func TestRevokeToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().RevokeToken(gomock.Any(), tt.refreshToken).Return(tt.revokeTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().RevokeToken(context.Background(), tt.refreshToken).Return(tt.revokeTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
@@ -279,7 +279,7 @@ func TestLogout(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().Logout(gomock.Any(), tt.returnTo).Return("logout url", tt.logoutErr).AnyTimes()
+			mockIdentityProvider.EXPECT().Logout(context.Background(), tt.returnTo).Return("logout url", tt.logoutErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 
@@ -330,7 +330,7 @@ func TestGetM2MToken(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockIdentityProvider := mocks.NewMockProvider(ctrl)
-			mockIdentityProvider.EXPECT().GetM2MToken(gomock.Any(), tt.clientID, tt.clientSecret).Return(tt.tokenResult, tt.getM2MTokenErr).AnyTimes()
+			mockIdentityProvider.EXPECT().GetM2MToken(context.Background(), tt.clientID, tt.clientSecret).Return(tt.tokenResult, tt.getM2MTokenErr).AnyTimes()
 
 			authUsecase := NewAuthUsecase(mockIdentityProvider)
 

--- a/internal/application/identity/provider.go
+++ b/internal/application/identity/provider.go
@@ -1,5 +1,7 @@
 package identity
 
+import "context"
+
 type TokenResult struct {
 	AccessToken  string
 	RefreshToken string
@@ -10,11 +12,11 @@ type VerifyResult struct {
 }
 
 type Provider interface {
-	Login(redirectURI string) (string, error)
-	ExchangeCode(code, redirectURI string) (*TokenResult, error)
-	VerifyToken(accessToken string) (*VerifyResult, error)
-	RefreshToken(refreshToken string) (*TokenResult, error)
-	RevokeToken(refreshToken string) error
-	Logout(returnTo string) (string, error)
-	GetM2MToken(clientID, clientSecret string) (*TokenResult, error)
+	Login(ctx context.Context, redirectURI string) (string, error)
+	ExchangeCode(ctx context.Context, code, redirectURI string) (*TokenResult, error)
+	VerifyToken(ctx context.Context, accessToken string) (*VerifyResult, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*TokenResult, error)
+	RevokeToken(ctx context.Context, refreshToken string) error
+	Logout(ctx context.Context, returnTo string) (string, error)
+	GetM2MToken(ctx context.Context, clientID, clientSecret string) (*TokenResult, error)
 }

--- a/internal/infrastructure/api/auth0/client.go
+++ b/internal/infrastructure/api/auth0/client.go
@@ -2,6 +2,7 @@ package auth0
 
 import (
 	"bytes"
+	"context"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
@@ -35,7 +36,7 @@ func NewClient(baseURL, clientID, clientSecret, audience string, timeout time.Du
 	}
 }
 
-func (c *client) Login(redirectURI string) (string, error) {
+func (c *client) Login(ctx context.Context, redirectURI string) (string, error) {
 	endpoint := fmt.Sprintf("%s/authorize", c.baseURL)
 
 	params := url.Values{}
@@ -50,7 +51,7 @@ func (c *client) Login(redirectURI string) (string, error) {
 	return loginURL, nil
 }
 
-func (c *client) ExchangeCode(code, redirectURI string) (*identity.TokenResult, error) {
+func (c *client) ExchangeCode(ctx context.Context, code, redirectURI string) (*identity.TokenResult, error) {
 	endpoint := fmt.Sprintf("%s/oauth/token", c.baseURL)
 
 	data := url.Values{}
@@ -60,7 +61,7 @@ func (c *client) ExchangeCode(code, redirectURI string) (*identity.TokenResult, 
 	data.Set("client_secret", c.clientSecret)
 	data.Set("redirect_uri", redirectURI)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -87,10 +88,10 @@ func (c *client) ExchangeCode(code, redirectURI string) (*identity.TokenResult, 
 	}, nil
 }
 
-func (c *client) VerifyToken(accessToken string) (*identity.VerifyResult, error) {
+func (c *client) VerifyToken(ctx context.Context, accessToken string) (*identity.VerifyResult, error) {
 	endpoint := fmt.Sprintf("%s/.well-known/jwks.json", c.baseURL)
 
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +165,7 @@ func (c *client) VerifyToken(accessToken string) (*identity.VerifyResult, error)
 	return &identity.VerifyResult{Subject: subject}, nil
 }
 
-func (c *client) RefreshToken(refreshToken string) (*identity.TokenResult, error) {
+func (c *client) RefreshToken(ctx context.Context, refreshToken string) (*identity.TokenResult, error) {
 	endpoint := fmt.Sprintf("%s/oauth/token", c.baseURL)
 
 	data := url.Values{}
@@ -173,7 +174,7 @@ func (c *client) RefreshToken(refreshToken string) (*identity.TokenResult, error
 	data.Set("client_id", c.clientID)
 	data.Set("client_secret", c.clientSecret)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (c *client) RefreshToken(refreshToken string) (*identity.TokenResult, error
 	}, nil
 }
 
-func (c *client) RevokeToken(refreshToken string) error {
+func (c *client) RevokeToken(ctx context.Context, refreshToken string) error {
 	endpoint := fmt.Sprintf("%s/oauth/revoke", c.baseURL)
 
 	data := url.Values{}
@@ -208,7 +209,7 @@ func (c *client) RevokeToken(refreshToken string) error {
 	data.Set("client_secret", c.clientSecret)
 	data.Set("token", refreshToken)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return err
 	}
@@ -227,7 +228,7 @@ func (c *client) RevokeToken(refreshToken string) error {
 	return nil
 }
 
-func (c *client) Logout(returnTo string) (string, error) {
+func (c *client) Logout(ctx context.Context, returnTo string) (string, error) {
 	endpoint := fmt.Sprintf("%s/v2/logout", c.baseURL)
 
 	params := url.Values{}
@@ -239,7 +240,7 @@ func (c *client) Logout(returnTo string) (string, error) {
 	return logoutURL, nil
 }
 
-func (c *client) GetM2MToken(clientID, clientSecret string) (*identity.TokenResult, error) {
+func (c *client) GetM2MToken(ctx context.Context, clientID, clientSecret string) (*identity.TokenResult, error) {
 	endpoint := fmt.Sprintf("%s/oauth/token", c.baseURL)
 
 	data := url.Values{}
@@ -248,7 +249,7 @@ func (c *client) GetM2MToken(clientID, clientSecret string) (*identity.TokenResu
 	data.Set("client_secret", clientSecret)
 	data.Set("audience", c.audience)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/api/auth0/client_test.go
+++ b/internal/infrastructure/api/auth0/client_test.go
@@ -1,14 +1,15 @@
 package auth0
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"math/big"
 	"net/http"
-	"reflect"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -45,7 +46,7 @@ func TestLogin(t *testing.T) {
 
 			client := NewClient(tt.baseURL, tt.clientID, "clientSecret", tt.audience, 1*time.Second)
 
-			loginURL, err := client.Login(tt.redirectURI)
+			loginURL, err := client.Login(context.Background(), tt.redirectURI)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -132,7 +133,7 @@ func TestExchangeCode(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "audience", 1*time.Second)
 
-			token, err := client.ExchangeCode(tt.code, tt.redirectURI)
+			token, err := client.ExchangeCode(context.Background(), tt.code, tt.redirectURI)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -312,7 +313,7 @@ func TestVerifyToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "audience", 1*time.Second)
 
-			_, err := client.VerifyToken(tt.accessToken)
+			_, err := client.VerifyToken(context.Background(), tt.accessToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -389,7 +390,7 @@ func TestRefreshToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "audience", 1*time.Second)
 
-			token, err := client.RefreshToken(tt.refreshToken)
+			token, err := client.RefreshToken(context.Background(), tt.refreshToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -448,7 +449,7 @@ func TestRevokeToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "audience", 1*time.Second)
 
-			err := client.RevokeToken(tt.refreshToken)
+			err := client.RevokeToken(context.Background(), tt.refreshToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -485,7 +486,7 @@ func TestLogout(t *testing.T) {
 
 			client := NewClient(tt.baseURL, tt.clientID, "clientSecret", "audience", 1*time.Second)
 
-			logoutURL, err := client.Logout(tt.returnTo)
+			logoutURL, err := client.Logout(context.Background(), tt.returnTo)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -559,7 +560,7 @@ func TestGetM2MToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "audience", 1*time.Second)
 
-			token, err := client.GetM2MToken("m2mClientID", "m2mClientSecret")
+			token, err := client.GetM2MToken(context.Background(), "m2mClientID", "m2mClientSecret")
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}

--- a/internal/infrastructure/api/keycloak/client.go
+++ b/internal/infrastructure/api/keycloak/client.go
@@ -2,6 +2,7 @@ package keycloak
 
 import (
 	"bytes"
+	"context"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
@@ -36,11 +37,11 @@ func NewClient(baseURL, clientID, clientSecret, realm string, timeout time.Durat
 	}
 }
 
-func (c *client) Login(redirectURI string) (string, error) {
+func (c *client) Login(ctx context.Context, redirectURI string) (string, error) {
 	return "", errors.New("not implemented")
 }
 
-func (c *client) ExchangeCode(code, redirectURI string) (*identity.TokenResult, error) {
+func (c *client) ExchangeCode(ctx context.Context, code, redirectURI string) (*identity.TokenResult, error) {
 	endpoint := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token", c.baseURL, c.realm)
 
 	data := url.Values{}
@@ -50,7 +51,7 @@ func (c *client) ExchangeCode(code, redirectURI string) (*identity.TokenResult, 
 	data.Set("client_secret", c.clientSecret)
 	data.Set("redirect_uri", redirectURI)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -77,10 +78,10 @@ func (c *client) ExchangeCode(code, redirectURI string) (*identity.TokenResult, 
 	}, nil
 }
 
-func (c *client) VerifyToken(accessToken string) (*identity.VerifyResult, error) {
+func (c *client) VerifyToken(ctx context.Context, accessToken string) (*identity.VerifyResult, error) {
 	endpoint := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", c.baseURL, c.realm)
 
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func (c *client) VerifyToken(accessToken string) (*identity.VerifyResult, error)
 	return &identity.VerifyResult{Subject: subject}, nil
 }
 
-func (c *client) RefreshToken(refreshToken string) (*identity.TokenResult, error) {
+func (c *client) RefreshToken(ctx context.Context, refreshToken string) (*identity.TokenResult, error) {
 	endpoint := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token", c.baseURL, c.realm)
 
 	data := url.Values{}
@@ -163,7 +164,7 @@ func (c *client) RefreshToken(refreshToken string) (*identity.TokenResult, error
 	data.Set("client_id", c.clientID)
 	data.Set("client_secret", c.clientSecret)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (c *client) RefreshToken(refreshToken string) (*identity.TokenResult, error
 	}, nil
 }
 
-func (c *client) RevokeToken(refreshToken string) error {
+func (c *client) RevokeToken(ctx context.Context, refreshToken string) error {
 	endpoint := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/logout", c.baseURL, c.realm)
 
 	data := url.Values{}
@@ -198,7 +199,7 @@ func (c *client) RevokeToken(refreshToken string) error {
 	data.Set("client_secret", c.clientSecret)
 	data.Set("refresh_token", refreshToken)
 
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return err
 	}
@@ -217,10 +218,10 @@ func (c *client) RevokeToken(refreshToken string) error {
 	return nil
 }
 
-func (c *client) Logout(returnTo string) (string, error) {
+func (c *client) Logout(ctx context.Context, returnTo string) (string, error) {
 	return "", errors.New("not implemented")
 }
 
-func (c *client) GetM2MToken(clientID, clientSecret string) (*identity.TokenResult, error) {
+func (c *client) GetM2MToken(ctx context.Context, clientID, clientSecret string) (*identity.TokenResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/infrastructure/api/keycloak/client_test.go
+++ b/internal/infrastructure/api/keycloak/client_test.go
@@ -1,14 +1,15 @@
 package keycloak
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"math/big"
 	"net/http"
-	"reflect"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -89,7 +90,7 @@ func TestExchangeCode(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "realm", 1*time.Second)
 
-			token, err := client.ExchangeCode(tt.code, tt.redirectURI)
+			token, err := client.ExchangeCode(context.Background(), tt.code, tt.redirectURI)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -269,7 +270,7 @@ func TestVerifyToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "realm", 1*time.Second)
 
-			_, err := client.VerifyToken(tt.accessToken)
+			_, err := client.VerifyToken(context.Background(), tt.accessToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -346,7 +347,7 @@ func TestRefreshToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "realm", 1*time.Second)
 
-			token, err := client.RefreshToken(tt.refreshToken)
+			token, err := client.RefreshToken(context.Background(), tt.refreshToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}
@@ -405,7 +406,7 @@ func TestRevokeToken(t *testing.T) {
 
 			client := NewClient(server.URL, "clientID", "clientSecret", "realm", 1*time.Second)
 
-			err := client.RevokeToken(tt.refreshToken)
+			err := client.RevokeToken(context.Background(), tt.refreshToken)
 			if tt.success && err != nil {
 				t.Errorf("expected no error, but got %v", err)
 			}

--- a/internal/interface/grpc/auth/handler.go
+++ b/internal/interface/grpc/auth/handler.go
@@ -24,7 +24,7 @@ func NewAuthHandler(authUsecase auth.AuthUsecase) *AuthHandler {
 }
 
 func (h *AuthHandler) Login(ctx context.Context, req *authv1.LoginRequest) (*authv1.LoginResponse, error) {
-	url, err := h.authUsecase.Login(req.GetRedirectUri())
+	url, err := h.authUsecase.Login(ctx, req.GetRedirectUri())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -39,7 +39,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *authv1.LoginRequest) (*aut
 }
 
 func (h *AuthHandler) ExchangeCode(ctx context.Context, req *authv1.ExchangeCodeRequest) (*authv1.ExchangeCodeResponse, error) {
-	token, err := h.authUsecase.ExchangeCode(req.GetCode(), req.GetRedirectUri())
+	token, err := h.authUsecase.ExchangeCode(ctx, req.GetCode(), req.GetRedirectUri())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -48,7 +48,7 @@ func (h *AuthHandler) ExchangeCode(ctx context.Context, req *authv1.ExchangeCode
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	user, err := h.authUsecase.VerifyToken(token.AccessToken())
+	user, err := h.authUsecase.VerifyToken(ctx, token.AccessToken())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -85,7 +85,7 @@ func (h *AuthHandler) VerifyToken(ctx context.Context, req *authv1.VerifyTokenRe
 
 	accessToken := strings.TrimPrefix(token, "Bearer ")
 
-	user, err := h.authUsecase.VerifyToken(accessToken)
+	user, err := h.authUsecase.VerifyToken(ctx, accessToken)
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -112,7 +112,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *authv1.RefreshToken
 
 	refreshToken := refreshTokens[0]
 
-	token, err := h.authUsecase.RefreshToken(refreshToken)
+	token, err := h.authUsecase.RefreshToken(ctx, refreshToken)
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -143,7 +143,7 @@ func (h *AuthHandler) RevokeToken(ctx context.Context, req *authv1.RevokeTokenRe
 
 	refreshToken := refreshTokens[0]
 
-	if err := h.authUsecase.RevokeToken(refreshToken); err != nil {
+	if err := h.authUsecase.RevokeToken(ctx, refreshToken); err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
 		}
@@ -155,7 +155,7 @@ func (h *AuthHandler) RevokeToken(ctx context.Context, req *authv1.RevokeTokenRe
 }
 
 func (h *AuthHandler) Logout(ctx context.Context, req *authv1.LogoutRequest) (*authv1.LogoutResponse, error) {
-	url, err := h.authUsecase.Logout(req.GetReturnTo())
+	url, err := h.authUsecase.Logout(ctx, req.GetReturnTo())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
@@ -170,7 +170,7 @@ func (h *AuthHandler) Logout(ctx context.Context, req *authv1.LogoutRequest) (*a
 }
 
 func (h *AuthHandler) GetM2MToken(ctx context.Context, req *authv1.GetM2MTokenRequest) (*authv1.GetM2MTokenResponse, error) {
-	m2mToken, err := h.authUsecase.GetM2MToken(req.GetClientId(), req.GetClientSecret())
+	m2mToken, err := h.authUsecase.GetM2MToken(ctx, req.GetClientId(), req.GetClientSecret())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err

--- a/internal/interface/grpc/auth/handler_test.go
+++ b/internal/interface/grpc/auth/handler_test.go
@@ -39,7 +39,7 @@ func TestLogin(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
-			mockUsecase.EXPECT().Login(tt.redirectURI).Return("login url", tt.loginErr).Times(1)
+			mockUsecase.EXPECT().Login(gomock.Any(), tt.redirectURI).Return("login url", tt.loginErr).Times(1)
 
 			handler := NewAuthHandler(mockUsecase)
 
@@ -83,9 +83,9 @@ func TestExchangeCode(t *testing.T) {
 			mockToken.EXPECT().AccessToken().Return("accessToken").AnyTimes()
 			mockToken.EXPECT().RefreshToken().Return("refreshToken").AnyTimes()
 			mockUser.EXPECT().ID().Return(user.UserID("fe8c2263-bbac-4bb9-a41d-b04f5afc4425")).AnyTimes()
-			mockUsecase.EXPECT().ExchangeCode(tt.code, tt.redirectURI).Return(mockToken, tt.exchangeErr).Times(1)
+			mockUsecase.EXPECT().ExchangeCode(gomock.Any(), tt.code, tt.redirectURI).Return(mockToken, tt.exchangeErr).Times(1)
 			if tt.callVerify {
-				mockUsecase.EXPECT().VerifyToken("accessToken").Return(mockUser, tt.verifyTokenErr).Times(1)
+				mockUsecase.EXPECT().VerifyToken(gomock.Any(), "accessToken").Return(mockUser, tt.verifyTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -128,7 +128,7 @@ func TestVerifyToken(t *testing.T) {
 			mockUser := mocksuser.NewMockUser(ctrl)
 			mockUser.EXPECT().ID().Return(user.UserID("fe8c2263-bbac-4bb9-a41d-b04f5afc4425")).AnyTimes()
 			if tt.callUsecase {
-				mockUsecase.EXPECT().VerifyToken(accessToken).Return(mockUser, tt.verifyTokenErr).Times(1)
+				mockUsecase.EXPECT().VerifyToken(gomock.Any(), accessToken).Return(mockUser, tt.verifyTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -170,7 +170,7 @@ func TestRefreshToken(t *testing.T) {
 			mockToken.EXPECT().AccessToken().Return("accessToken").AnyTimes()
 			mockToken.EXPECT().RefreshToken().Return("refreshToken").AnyTimes()
 			if tt.callUsecase {
-				mockUsecase.EXPECT().RefreshToken(refreshToken).Return(mockToken, tt.refreshTokenErr).Times(1)
+				mockUsecase.EXPECT().RefreshToken(gomock.Any(), refreshToken).Return(mockToken, tt.refreshTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -209,7 +209,7 @@ func TestRevokeToken(t *testing.T) {
 
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
 			if tt.callUsecase {
-				mockUsecase.EXPECT().RevokeToken(refreshToken).Return(tt.revokeTokenErr).Times(1)
+				mockUsecase.EXPECT().RevokeToken(gomock.Any(), refreshToken).Return(tt.revokeTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -244,7 +244,7 @@ func TestLogout(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
-			mockUsecase.EXPECT().Logout(tt.returnTo).Return("logout url", tt.logoutErr).Times(1)
+			mockUsecase.EXPECT().Logout(gomock.Any(), tt.returnTo).Return("logout url", tt.logoutErr).Times(1)
 
 			handler := NewAuthHandler(mockUsecase)
 
@@ -281,7 +281,7 @@ func TestGetM2MToken(t *testing.T) {
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
 			mockM2MToken := mockstoken.NewMockM2MToken(ctrl)
 			mockM2MToken.EXPECT().AccessToken().Return("m2mAccessToken").AnyTimes()
-			mockUsecase.EXPECT().GetM2MToken(tt.clientID, tt.clientSecret).Return(mockM2MToken, tt.getM2MTokenErr).Times(1)
+			mockUsecase.EXPECT().GetM2MToken(gomock.Any(), tt.clientID, tt.clientSecret).Return(mockM2MToken, tt.getM2MTokenErr).Times(1)
 
 			handler := NewAuthHandler(mockUsecase)
 

--- a/internal/interface/grpc/auth/handler_test.go
+++ b/internal/interface/grpc/auth/handler_test.go
@@ -39,7 +39,7 @@ func TestLogin(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
-			mockUsecase.EXPECT().Login(gomock.Any(), tt.redirectURI).Return("login url", tt.loginErr).Times(1)
+			mockUsecase.EXPECT().Login(tt.ctx, tt.redirectURI).Return("login url", tt.loginErr).Times(1)
 
 			handler := NewAuthHandler(mockUsecase)
 
@@ -83,9 +83,9 @@ func TestExchangeCode(t *testing.T) {
 			mockToken.EXPECT().AccessToken().Return("accessToken").AnyTimes()
 			mockToken.EXPECT().RefreshToken().Return("refreshToken").AnyTimes()
 			mockUser.EXPECT().ID().Return(user.UserID("fe8c2263-bbac-4bb9-a41d-b04f5afc4425")).AnyTimes()
-			mockUsecase.EXPECT().ExchangeCode(gomock.Any(), tt.code, tt.redirectURI).Return(mockToken, tt.exchangeErr).Times(1)
+			mockUsecase.EXPECT().ExchangeCode(tt.ctx, tt.code, tt.redirectURI).Return(mockToken, tt.exchangeErr).Times(1)
 			if tt.callVerify {
-				mockUsecase.EXPECT().VerifyToken(gomock.Any(), "accessToken").Return(mockUser, tt.verifyTokenErr).Times(1)
+				mockUsecase.EXPECT().VerifyToken(tt.ctx, "accessToken").Return(mockUser, tt.verifyTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -128,7 +128,7 @@ func TestVerifyToken(t *testing.T) {
 			mockUser := mocksuser.NewMockUser(ctrl)
 			mockUser.EXPECT().ID().Return(user.UserID("fe8c2263-bbac-4bb9-a41d-b04f5afc4425")).AnyTimes()
 			if tt.callUsecase {
-				mockUsecase.EXPECT().VerifyToken(gomock.Any(), accessToken).Return(mockUser, tt.verifyTokenErr).Times(1)
+				mockUsecase.EXPECT().VerifyToken(tt.ctx, accessToken).Return(mockUser, tt.verifyTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -170,7 +170,7 @@ func TestRefreshToken(t *testing.T) {
 			mockToken.EXPECT().AccessToken().Return("accessToken").AnyTimes()
 			mockToken.EXPECT().RefreshToken().Return("refreshToken").AnyTimes()
 			if tt.callUsecase {
-				mockUsecase.EXPECT().RefreshToken(gomock.Any(), refreshToken).Return(mockToken, tt.refreshTokenErr).Times(1)
+				mockUsecase.EXPECT().RefreshToken(tt.ctx, refreshToken).Return(mockToken, tt.refreshTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -209,7 +209,7 @@ func TestRevokeToken(t *testing.T) {
 
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
 			if tt.callUsecase {
-				mockUsecase.EXPECT().RevokeToken(gomock.Any(), refreshToken).Return(tt.revokeTokenErr).Times(1)
+				mockUsecase.EXPECT().RevokeToken(tt.ctx, refreshToken).Return(tt.revokeTokenErr).Times(1)
 			}
 
 			handler := NewAuthHandler(mockUsecase)
@@ -244,7 +244,7 @@ func TestLogout(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
-			mockUsecase.EXPECT().Logout(gomock.Any(), tt.returnTo).Return("logout url", tt.logoutErr).Times(1)
+			mockUsecase.EXPECT().Logout(tt.ctx, tt.returnTo).Return("logout url", tt.logoutErr).Times(1)
 
 			handler := NewAuthHandler(mockUsecase)
 
@@ -281,7 +281,7 @@ func TestGetM2MToken(t *testing.T) {
 			mockUsecase := mocksappauth.NewMockAuthUsecase(ctrl)
 			mockM2MToken := mockstoken.NewMockM2MToken(ctrl)
 			mockM2MToken.EXPECT().AccessToken().Return("m2mAccessToken").AnyTimes()
-			mockUsecase.EXPECT().GetM2MToken(gomock.Any(), tt.clientID, tt.clientSecret).Return(mockM2MToken, tt.getM2MTokenErr).Times(1)
+			mockUsecase.EXPECT().GetM2MToken(tt.ctx, tt.clientID, tt.clientSecret).Return(mockM2MToken, tt.getM2MTokenErr).Times(1)
 
 			handler := NewAuthHandler(mockUsecase)
 

--- a/mocks/application/auth/mock_usecase.go
+++ b/mocks/application/auth/mock_usecase.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	token "github.com/qkitzero/auth-service/internal/domain/token"
@@ -42,105 +43,105 @@ func (m *MockAuthUsecase) EXPECT() *MockAuthUsecaseMockRecorder {
 }
 
 // ExchangeCode mocks base method.
-func (m *MockAuthUsecase) ExchangeCode(code, redirectURI string) (token.Token, error) {
+func (m *MockAuthUsecase) ExchangeCode(ctx context.Context, code, redirectURI string) (token.Token, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExchangeCode", code, redirectURI)
+	ret := m.ctrl.Call(m, "ExchangeCode", ctx, code, redirectURI)
 	ret0, _ := ret[0].(token.Token)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExchangeCode indicates an expected call of ExchangeCode.
-func (mr *MockAuthUsecaseMockRecorder) ExchangeCode(code, redirectURI any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) ExchangeCode(ctx, code, redirectURI any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeCode", reflect.TypeOf((*MockAuthUsecase)(nil).ExchangeCode), code, redirectURI)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeCode", reflect.TypeOf((*MockAuthUsecase)(nil).ExchangeCode), ctx, code, redirectURI)
 }
 
 // GetM2MToken mocks base method.
-func (m *MockAuthUsecase) GetM2MToken(clientID, clientSecret string) (token.M2MToken, error) {
+func (m *MockAuthUsecase) GetM2MToken(ctx context.Context, clientID, clientSecret string) (token.M2MToken, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetM2MToken", clientID, clientSecret)
+	ret := m.ctrl.Call(m, "GetM2MToken", ctx, clientID, clientSecret)
 	ret0, _ := ret[0].(token.M2MToken)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetM2MToken indicates an expected call of GetM2MToken.
-func (mr *MockAuthUsecaseMockRecorder) GetM2MToken(clientID, clientSecret any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) GetM2MToken(ctx, clientID, clientSecret any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetM2MToken", reflect.TypeOf((*MockAuthUsecase)(nil).GetM2MToken), clientID, clientSecret)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetM2MToken", reflect.TypeOf((*MockAuthUsecase)(nil).GetM2MToken), ctx, clientID, clientSecret)
 }
 
 // Login mocks base method.
-func (m *MockAuthUsecase) Login(redirectURI string) (string, error) {
+func (m *MockAuthUsecase) Login(ctx context.Context, redirectURI string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", redirectURI)
+	ret := m.ctrl.Call(m, "Login", ctx, redirectURI)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.
-func (mr *MockAuthUsecaseMockRecorder) Login(redirectURI any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) Login(ctx, redirectURI any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockAuthUsecase)(nil).Login), redirectURI)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockAuthUsecase)(nil).Login), ctx, redirectURI)
 }
 
 // Logout mocks base method.
-func (m *MockAuthUsecase) Logout(returnTo string) (string, error) {
+func (m *MockAuthUsecase) Logout(ctx context.Context, returnTo string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Logout", returnTo)
+	ret := m.ctrl.Call(m, "Logout", ctx, returnTo)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Logout indicates an expected call of Logout.
-func (mr *MockAuthUsecaseMockRecorder) Logout(returnTo any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) Logout(ctx, returnTo any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logout", reflect.TypeOf((*MockAuthUsecase)(nil).Logout), returnTo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logout", reflect.TypeOf((*MockAuthUsecase)(nil).Logout), ctx, returnTo)
 }
 
 // RefreshToken mocks base method.
-func (m *MockAuthUsecase) RefreshToken(refreshToken string) (token.Token, error) {
+func (m *MockAuthUsecase) RefreshToken(ctx context.Context, refreshToken string) (token.Token, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshToken", refreshToken)
+	ret := m.ctrl.Call(m, "RefreshToken", ctx, refreshToken)
 	ret0, _ := ret[0].(token.Token)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RefreshToken indicates an expected call of RefreshToken.
-func (mr *MockAuthUsecaseMockRecorder) RefreshToken(refreshToken any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) RefreshToken(ctx, refreshToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshToken", reflect.TypeOf((*MockAuthUsecase)(nil).RefreshToken), refreshToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshToken", reflect.TypeOf((*MockAuthUsecase)(nil).RefreshToken), ctx, refreshToken)
 }
 
 // RevokeToken mocks base method.
-func (m *MockAuthUsecase) RevokeToken(refreshToken string) error {
+func (m *MockAuthUsecase) RevokeToken(ctx context.Context, refreshToken string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevokeToken", refreshToken)
+	ret := m.ctrl.Call(m, "RevokeToken", ctx, refreshToken)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RevokeToken indicates an expected call of RevokeToken.
-func (mr *MockAuthUsecaseMockRecorder) RevokeToken(refreshToken any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) RevokeToken(ctx, refreshToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockAuthUsecase)(nil).RevokeToken), refreshToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockAuthUsecase)(nil).RevokeToken), ctx, refreshToken)
 }
 
 // VerifyToken mocks base method.
-func (m *MockAuthUsecase) VerifyToken(accessToken string) (user.User, error) {
+func (m *MockAuthUsecase) VerifyToken(ctx context.Context, accessToken string) (user.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyToken", accessToken)
+	ret := m.ctrl.Call(m, "VerifyToken", ctx, accessToken)
 	ret0, _ := ret[0].(user.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VerifyToken indicates an expected call of VerifyToken.
-func (mr *MockAuthUsecaseMockRecorder) VerifyToken(accessToken any) *gomock.Call {
+func (mr *MockAuthUsecaseMockRecorder) VerifyToken(ctx, accessToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyToken", reflect.TypeOf((*MockAuthUsecase)(nil).VerifyToken), accessToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyToken", reflect.TypeOf((*MockAuthUsecase)(nil).VerifyToken), ctx, accessToken)
 }

--- a/mocks/application/identity/mock_provider.go
+++ b/mocks/application/identity/mock_provider.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	identity "github.com/qkitzero/auth-service/internal/application/identity"
@@ -41,105 +42,105 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // ExchangeCode mocks base method.
-func (m *MockProvider) ExchangeCode(code, redirectURI string) (*identity.TokenResult, error) {
+func (m *MockProvider) ExchangeCode(ctx context.Context, code, redirectURI string) (*identity.TokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExchangeCode", code, redirectURI)
+	ret := m.ctrl.Call(m, "ExchangeCode", ctx, code, redirectURI)
 	ret0, _ := ret[0].(*identity.TokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExchangeCode indicates an expected call of ExchangeCode.
-func (mr *MockProviderMockRecorder) ExchangeCode(code, redirectURI any) *gomock.Call {
+func (mr *MockProviderMockRecorder) ExchangeCode(ctx, code, redirectURI any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeCode", reflect.TypeOf((*MockProvider)(nil).ExchangeCode), code, redirectURI)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeCode", reflect.TypeOf((*MockProvider)(nil).ExchangeCode), ctx, code, redirectURI)
 }
 
 // GetM2MToken mocks base method.
-func (m *MockProvider) GetM2MToken(clientID, clientSecret string) (*identity.TokenResult, error) {
+func (m *MockProvider) GetM2MToken(ctx context.Context, clientID, clientSecret string) (*identity.TokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetM2MToken", clientID, clientSecret)
+	ret := m.ctrl.Call(m, "GetM2MToken", ctx, clientID, clientSecret)
 	ret0, _ := ret[0].(*identity.TokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetM2MToken indicates an expected call of GetM2MToken.
-func (mr *MockProviderMockRecorder) GetM2MToken(clientID, clientSecret any) *gomock.Call {
+func (mr *MockProviderMockRecorder) GetM2MToken(ctx, clientID, clientSecret any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetM2MToken", reflect.TypeOf((*MockProvider)(nil).GetM2MToken), clientID, clientSecret)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetM2MToken", reflect.TypeOf((*MockProvider)(nil).GetM2MToken), ctx, clientID, clientSecret)
 }
 
 // Login mocks base method.
-func (m *MockProvider) Login(redirectURI string) (string, error) {
+func (m *MockProvider) Login(ctx context.Context, redirectURI string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", redirectURI)
+	ret := m.ctrl.Call(m, "Login", ctx, redirectURI)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.
-func (mr *MockProviderMockRecorder) Login(redirectURI any) *gomock.Call {
+func (mr *MockProviderMockRecorder) Login(ctx, redirectURI any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockProvider)(nil).Login), redirectURI)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockProvider)(nil).Login), ctx, redirectURI)
 }
 
 // Logout mocks base method.
-func (m *MockProvider) Logout(returnTo string) (string, error) {
+func (m *MockProvider) Logout(ctx context.Context, returnTo string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Logout", returnTo)
+	ret := m.ctrl.Call(m, "Logout", ctx, returnTo)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Logout indicates an expected call of Logout.
-func (mr *MockProviderMockRecorder) Logout(returnTo any) *gomock.Call {
+func (mr *MockProviderMockRecorder) Logout(ctx, returnTo any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logout", reflect.TypeOf((*MockProvider)(nil).Logout), returnTo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logout", reflect.TypeOf((*MockProvider)(nil).Logout), ctx, returnTo)
 }
 
 // RefreshToken mocks base method.
-func (m *MockProvider) RefreshToken(refreshToken string) (*identity.TokenResult, error) {
+func (m *MockProvider) RefreshToken(ctx context.Context, refreshToken string) (*identity.TokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshToken", refreshToken)
+	ret := m.ctrl.Call(m, "RefreshToken", ctx, refreshToken)
 	ret0, _ := ret[0].(*identity.TokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RefreshToken indicates an expected call of RefreshToken.
-func (mr *MockProviderMockRecorder) RefreshToken(refreshToken any) *gomock.Call {
+func (mr *MockProviderMockRecorder) RefreshToken(ctx, refreshToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshToken", reflect.TypeOf((*MockProvider)(nil).RefreshToken), refreshToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshToken", reflect.TypeOf((*MockProvider)(nil).RefreshToken), ctx, refreshToken)
 }
 
 // RevokeToken mocks base method.
-func (m *MockProvider) RevokeToken(refreshToken string) error {
+func (m *MockProvider) RevokeToken(ctx context.Context, refreshToken string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevokeToken", refreshToken)
+	ret := m.ctrl.Call(m, "RevokeToken", ctx, refreshToken)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RevokeToken indicates an expected call of RevokeToken.
-func (mr *MockProviderMockRecorder) RevokeToken(refreshToken any) *gomock.Call {
+func (mr *MockProviderMockRecorder) RevokeToken(ctx, refreshToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockProvider)(nil).RevokeToken), refreshToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockProvider)(nil).RevokeToken), ctx, refreshToken)
 }
 
 // VerifyToken mocks base method.
-func (m *MockProvider) VerifyToken(accessToken string) (*identity.VerifyResult, error) {
+func (m *MockProvider) VerifyToken(ctx context.Context, accessToken string) (*identity.VerifyResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyToken", accessToken)
+	ret := m.ctrl.Call(m, "VerifyToken", ctx, accessToken)
 	ret0, _ := ret[0].(*identity.VerifyResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VerifyToken indicates an expected call of VerifyToken.
-func (mr *MockProviderMockRecorder) VerifyToken(accessToken any) *gomock.Call {
+func (mr *MockProviderMockRecorder) VerifyToken(ctx, accessToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyToken", reflect.TypeOf((*MockProvider)(nil).VerifyToken), accessToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyToken", reflect.TypeOf((*MockProvider)(nil).VerifyToken), ctx, accessToken)
 }


### PR DESCRIPTION
## Summary
- Add `ctx context.Context` as the first argument of every method on `AuthUsecase` and `identity.Provider`
- Propagate the gRPC handler `ctx` through `internal/interface/grpc/auth/handler.go` to the usecase
- Replace `http.NewRequest` with `http.NewRequestWithContext` in `internal/infrastructure/api/keycloak/client.go` and `internal/infrastructure/api/auth0/client.go` for every outbound call
- Regenerate mocks; update test call sites to pass `context.Background()`

Closes #183.

## Notes
- Analogous to [workout-service#16](https://github.com/qkitzero/workout-service/pull/16) (commit `update: propagate context through repositories`); the same plumbing applied to outbound HTTP instead of GORM
- `http.Client.Timeout` is preserved, but ctx is now the way callers can cancel or shorten a request
- Out of scope: handler-level deadlines, OpenTelemetry — this PR only wires the plumbing
- Pre-existing coverage gaps in `infrastructure/api/{keycloak,auth0}` are unchanged by this PR

## Test plan
- [x] `go test ./...` passes
- [x] `make mock-gen` produces clean mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)