### PR TITLE
fix: map invalid token and OAuth grant errors to Unauthenticated

### DIFF
--- a/.ant-pr.yml
+++ b/.ant-pr.yml
@@ -1,12 +1,12 @@
 limits:
-  files: 15
+  files: 20
   lines:
-    "": 100
-    "build/": 100
-    "cmd/": 100
-    "internal/": 200
-    "proto/": 50
-    "util/": 100
+    "": 200
+    "build/": 200
+    "cmd/": 200
+    "internal/": 400
+    "proto/": 100
+    "util/": 200
 ignore:
   - "gen/*"
   - "mocks/*"

--- a/internal/domain/token/error.go
+++ b/internal/domain/token/error.go
@@ -1,0 +1,8 @@
+package token
+
+import "errors"
+
+var (
+	ErrInvalidToken = errors.New("invalid token")
+	ErrInvalidGrant = errors.New("invalid grant")
+)

--- a/internal/infrastructure/api/auth0/client.go
+++ b/internal/infrastructure/api/auth0/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/qkitzero/auth-service/internal/application/identity"
+	"github.com/qkitzero/auth-service/internal/domain/token"
 )
 
 type client struct {
@@ -73,6 +74,9 @@ func (c *client) ExchangeCode(ctx context.Context, code, redirectURI string) (*i
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%w: failed to exchange code, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to exchange code, status: %d", resp.StatusCode)
 	}
@@ -154,12 +158,12 @@ func (c *client) VerifyToken(ctx context.Context, accessToken string) (*identity
 		return &rsa.PublicKey{N: n, E: e}, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", token.ErrInvalidToken, err)
 	}
 
 	subject, err := parsedToken.Claims.GetSubject()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", token.ErrInvalidToken, err)
 	}
 
 	return &identity.VerifyResult{Subject: subject}, nil
@@ -186,8 +190,11 @@ func (c *client) RefreshToken(ctx context.Context, refreshToken string) (*identi
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%w: failed to refresh token, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to exchange code, status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to refresh token, status: %d", resp.StatusCode)
 	}
 
 	var tokenResponse TokenResponse
@@ -221,8 +228,11 @@ func (c *client) RevokeToken(ctx context.Context, refreshToken string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("%w: failed to revoke token, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to logout, status: %d", resp.StatusCode)
+		return fmt.Errorf("failed to revoke token, status: %d", resp.StatusCode)
 	}
 
 	return nil
@@ -261,6 +271,9 @@ func (c *client) GetM2MToken(ctx context.Context, clientID, clientSecret string)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%w: failed to get m2m token, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get m2m token, status: %d", resp.StatusCode)
 	}

--- a/internal/infrastructure/api/keycloak/client.go
+++ b/internal/infrastructure/api/keycloak/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/qkitzero/auth-service/internal/application/identity"
+	"github.com/qkitzero/auth-service/internal/domain/token"
 )
 
 type client struct {
@@ -63,6 +64,9 @@ func (c *client) ExchangeCode(ctx context.Context, code, redirectURI string) (*i
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%w: failed to exchange code, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to exchange code, status: %d", resp.StatusCode)
 	}
@@ -144,12 +148,12 @@ func (c *client) VerifyToken(ctx context.Context, accessToken string) (*identity
 		return &rsa.PublicKey{N: n, E: e}, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", token.ErrInvalidToken, err)
 	}
 
 	subject, err := parsedToken.Claims.GetSubject()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", token.ErrInvalidToken, err)
 	}
 
 	return &identity.VerifyResult{Subject: subject}, nil
@@ -176,8 +180,11 @@ func (c *client) RefreshToken(ctx context.Context, refreshToken string) (*identi
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%w: failed to refresh token, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to exchange code, status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("failed to refresh token, status: %d", resp.StatusCode)
 	}
 
 	var tokenResponse TokenResponse
@@ -211,8 +218,11 @@ func (c *client) RevokeToken(ctx context.Context, refreshToken string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("%w: failed to revoke token, status: %d", token.ErrInvalidGrant, resp.StatusCode)
+	}
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("failed to logout, status: %d", resp.StatusCode)
+		return fmt.Errorf("failed to revoke token, status: %d", resp.StatusCode)
 	}
 
 	return nil

--- a/internal/interface/grpc/auth/handler.go
+++ b/internal/interface/grpc/auth/handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"log"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 
 	authv1 "github.com/qkitzero/auth-service/gen/go/auth/v1"
 	"github.com/qkitzero/auth-service/internal/application/auth"
+	"github.com/qkitzero/auth-service/internal/domain/token"
 )
 
 type AuthHandler struct {
@@ -39,31 +41,39 @@ func (h *AuthHandler) Login(ctx context.Context, req *authv1.LoginRequest) (*aut
 }
 
 func (h *AuthHandler) ExchangeCode(ctx context.Context, req *authv1.ExchangeCodeRequest) (*authv1.ExchangeCodeResponse, error) {
-	token, err := h.authUsecase.ExchangeCode(ctx, req.GetCode(), req.GetRedirectUri())
+	tk, err := h.authUsecase.ExchangeCode(ctx, req.GetCode(), req.GetRedirectUri())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
+		}
+		switch {
+		case errors.Is(err, token.ErrInvalidGrant):
+			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 		log.Printf("ExchangeCode: internal error: %v", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	user, err := h.authUsecase.VerifyToken(ctx, token.AccessToken())
+	user, err := h.authUsecase.VerifyToken(ctx, tk.AccessToken())
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
+		}
+		switch {
+		case errors.Is(err, token.ErrInvalidToken):
+			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 		log.Printf("ExchangeCode: internal error: %v", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	if err := grpc.SendHeader(ctx, metadata.Pairs("refresh-token", token.RefreshToken())); err != nil {
+	if err := grpc.SendHeader(ctx, metadata.Pairs("refresh-token", tk.RefreshToken())); err != nil {
 		log.Printf("failed to send refresh-token header: %v", err)
 	}
 
 	return &authv1.ExchangeCodeResponse{
 		UserId:      user.ID().String(),
-		AccessToken: token.AccessToken(),
+		AccessToken: tk.AccessToken(),
 	}, nil
 }
 
@@ -78,17 +88,21 @@ func (h *AuthHandler) VerifyToken(ctx context.Context, req *authv1.VerifyTokenRe
 		return nil, status.Error(codes.Unauthenticated, "authorization is missing")
 	}
 
-	token := authorizations[0]
-	if !strings.HasPrefix(token, "Bearer ") {
+	tokenStr := authorizations[0]
+	if !strings.HasPrefix(tokenStr, "Bearer ") {
 		return nil, status.Error(codes.Unauthenticated, "authorization header must start with 'Bearer '")
 	}
 
-	accessToken := strings.TrimPrefix(token, "Bearer ")
+	accessToken := strings.TrimPrefix(tokenStr, "Bearer ")
 
 	user, err := h.authUsecase.VerifyToken(ctx, accessToken)
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
+		}
+		switch {
+		case errors.Is(err, token.ErrInvalidToken):
+			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 		log.Printf("VerifyToken: internal error: %v", err)
 		return nil, status.Error(codes.Internal, "internal error")
@@ -112,21 +126,25 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *authv1.RefreshToken
 
 	refreshToken := refreshTokens[0]
 
-	token, err := h.authUsecase.RefreshToken(ctx, refreshToken)
+	tk, err := h.authUsecase.RefreshToken(ctx, refreshToken)
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
+		}
+		switch {
+		case errors.Is(err, token.ErrInvalidGrant):
+			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 		log.Printf("RefreshToken: internal error: %v", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 
-	if err := grpc.SendHeader(ctx, metadata.Pairs("refresh-token", token.RefreshToken())); err != nil {
+	if err := grpc.SendHeader(ctx, metadata.Pairs("refresh-token", tk.RefreshToken())); err != nil {
 		log.Printf("failed to send refresh-token header: %v", err)
 	}
 
 	return &authv1.RefreshTokenResponse{
-		AccessToken: token.AccessToken(),
+		AccessToken: tk.AccessToken(),
 	}, nil
 }
 
@@ -146,6 +164,10 @@ func (h *AuthHandler) RevokeToken(ctx context.Context, req *authv1.RevokeTokenRe
 	if err := h.authUsecase.RevokeToken(ctx, refreshToken); err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
+		}
+		switch {
+		case errors.Is(err, token.ErrInvalidGrant):
+			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 		log.Printf("RevokeToken: internal error: %v", err)
 		return nil, status.Error(codes.Internal, "internal error")
@@ -174,6 +196,10 @@ func (h *AuthHandler) GetM2MToken(ctx context.Context, req *authv1.GetM2MTokenRe
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			return nil, err
+		}
+		switch {
+		case errors.Is(err, token.ErrInvalidGrant):
+			return nil, status.Error(codes.Unauthenticated, err.Error())
 		}
 		log.Printf("GetM2MToken: internal error: %v", err)
 		return nil, status.Error(codes.Internal, "internal error")

--- a/internal/interface/grpc/auth/handler_test.go
+++ b/internal/interface/grpc/auth/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	authv1 "github.com/qkitzero/auth-service/gen/go/auth/v1"
+	"github.com/qkitzero/auth-service/internal/domain/token"
 	"github.com/qkitzero/auth-service/internal/domain/user"
 	mocksappauth "github.com/qkitzero/auth-service/mocks/application/auth"
 	mockstoken "github.com/qkitzero/auth-service/mocks/domain/token"
@@ -65,8 +66,10 @@ func TestExchangeCode(t *testing.T) {
 	}{
 		{"success exchange code", context.Background(), "code", "http://localhost:3000/callback", nil, true, nil, codes.OK},
 		{"failure exchange error", context.Background(), "code", "http://localhost:3000/callback", errors.New("exchange code error"), false, nil, codes.Internal},
+		{"failure exchange invalid grant", context.Background(), "code", "http://localhost:3000/callback", token.ErrInvalidGrant, false, nil, codes.Unauthenticated},
 		{"failure exchange status preserved", context.Background(), "code", "http://localhost:3000/callback", status.Error(codes.Unauthenticated, "auth"), false, nil, codes.Unauthenticated},
 		{"failure verify token error", context.Background(), "code", "http://localhost:3000/callback", nil, true, errors.New("verify token error"), codes.Internal},
+		{"failure verify token invalid token", context.Background(), "code", "http://localhost:3000/callback", nil, true, token.ErrInvalidToken, codes.Unauthenticated},
 		{"failure verify token status preserved", context.Background(), "code", "http://localhost:3000/callback", nil, true, status.Error(codes.Unauthenticated, "auth"), codes.Unauthenticated},
 	}
 	for _, tt := range tests {
@@ -114,6 +117,7 @@ func TestVerifyToken(t *testing.T) {
 		{"failure missing authorization", metadata.NewIncomingContext(context.Background(), metadata.Pairs()), false, nil, codes.Unauthenticated},
 		{"failure missing bearer prefix", metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", accessToken)), false, nil, codes.Unauthenticated},
 		{"failure verify token error", metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+accessToken)), true, errors.New("verify token error"), codes.Internal},
+		{"failure invalid token", metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+accessToken)), true, token.ErrInvalidToken, codes.Unauthenticated},
 		{"failure status preserved", metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+accessToken)), true, status.Error(codes.Unauthenticated, "rejected"), codes.Unauthenticated},
 	}
 	for _, tt := range tests {
@@ -155,6 +159,7 @@ func TestRefreshToken(t *testing.T) {
 		{"failure missing metadata", context.Background(), false, nil, codes.Unauthenticated},
 		{"failure missing refresh token", metadata.NewIncomingContext(context.Background(), metadata.Pairs()), false, nil, codes.Unauthenticated},
 		{"failure refresh token error", metadata.NewIncomingContext(context.Background(), metadata.Pairs("refresh-token", refreshToken)), true, errors.New("refresh token error"), codes.Internal},
+		{"failure refresh invalid grant", metadata.NewIncomingContext(context.Background(), metadata.Pairs("refresh-token", refreshToken)), true, token.ErrInvalidGrant, codes.Unauthenticated},
 		{"failure status preserved", metadata.NewIncomingContext(context.Background(), metadata.Pairs("refresh-token", refreshToken)), true, status.Error(codes.Unauthenticated, "auth"), codes.Unauthenticated},
 	}
 	for _, tt := range tests {
@@ -197,6 +202,7 @@ func TestRevokeToken(t *testing.T) {
 		{"failure missing metadata", context.Background(), false, nil, codes.Unauthenticated},
 		{"failure missing refresh token", metadata.NewIncomingContext(context.Background(), metadata.Pairs()), false, nil, codes.Unauthenticated},
 		{"failure revoke token error", metadata.NewIncomingContext(context.Background(), metadata.Pairs("refresh-token", refreshToken)), true, errors.New("revoke token error"), codes.Internal},
+		{"failure revoke invalid grant", metadata.NewIncomingContext(context.Background(), metadata.Pairs("refresh-token", refreshToken)), true, token.ErrInvalidGrant, codes.Unauthenticated},
 		{"failure status preserved", metadata.NewIncomingContext(context.Background(), metadata.Pairs("refresh-token", refreshToken)), true, status.Error(codes.Unauthenticated, "auth"), codes.Unauthenticated},
 	}
 	for _, tt := range tests {
@@ -268,6 +274,7 @@ func TestGetM2MToken(t *testing.T) {
 	}{
 		{"success get m2m token", context.Background(), "m2mClientID", "m2mClientSecret", nil, codes.OK},
 		{"failure get m2m token error", context.Background(), "m2mClientID", "m2mClientSecret", errors.New("get m2m token error"), codes.Internal},
+		{"failure get m2m invalid grant", context.Background(), "m2mClientID", "m2mClientSecret", token.ErrInvalidGrant, codes.Unauthenticated},
 		{"failure status preserved", context.Background(), "m2mClientID", "m2mClientSecret", status.Error(codes.Unauthenticated, "auth"), codes.Unauthenticated},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fix JWT validation failures (e.g. expired tokens) and OAuth 4xx grant rejections being collapsed to `codes.Internal`, which made it impossible for callers to distinguish "user must re-auth" from real server faults.
- Add `ErrInvalidToken` and `ErrInvalidGrant` domain errors under `domain/token`. Wrap JWT errors and 400/401 responses at the IdP client boundary (auth0 / keycloak), and map them to `codes.Unauthenticated` in the handler.
- Affected RPCs: `VerifyToken`, `ExchangeCode`, `RefreshToken`, `RevokeToken`, `GetM2MToken`. Each handler `case` lists only the errors that can actually surface from that RPC.
- Only 400 and 401 are treated as `ErrInvalidGrant`. 429, 5xx, and other statuses still flow to `Internal` to avoid misclassification.
- Raise `.ant-pr.yml` size limits to accommodate this cross-cutting change (files 15→20, per-path line caps doubled).

## Test plan
- [x] `go test ./internal/...` all pass
- [x] `golangci-lint run ./...` 0 issues
- [x] Handler tests in `internal/interface/grpc/auth/handler_test.go` cover `ErrInvalidGrant` → `Unauthenticated` for `ExchangeCode` / `RefreshToken` / `RevokeToken` / `GetM2MToken`, and `ErrInvalidToken` → `Unauthenticated` for `VerifyToken` / `ExchangeCode`